### PR TITLE
light.py: remove duplicate config_entry_id

### DIFF
--- a/light.py
+++ b/light.py
@@ -95,8 +95,7 @@ class BeurerLight(LightEntity):
                 (DOMAIN, self._instance.mac)
             },
             "name": self.name,
-            "connections": {(device_registry.CONNECTION_NETWORK_MAC, self._instance.mac)},
-            "config_entry_id": self._entry_id
+            "connections": {(device_registry.CONNECTION_NETWORK_MAC, self._instance.mac)}
         }
 
     def _transform_color_brightness(self, color: Tuple[int, int, int], set_brightness: int):


### PR DESCRIPTION
The config_entry_id field gets added by the setup function itself. Returning it here adds the same parameter a second time.

resolves #5 