### PR TITLE
light.py: Adapt to upstream parameter change

### DIFF
--- a/light.py
+++ b/light.py
@@ -111,17 +111,14 @@ class BeurerLight(LightEntity):
         if len(kwargs) == 0:
             await self._instance.turn_on()
 
-        if ATTR_WHITE in kwargs:
-            await self._instance.set_white(kwargs[ATTR_WHITE])
+        if ATTR_BRIGHTNESS in kwargs and kwargs[ATTR_BRIGHTNESS]:
+            await self._instance.set_white(kwargs[ATTR_BRIGHTNESS])
 
-        if ATTR_RGB_COLOR in kwargs:
+        if ATTR_RGB_COLOR in kwargs and kwargs[ATTR_RGB_COLOR]:
             color = kwargs[ATTR_RGB_COLOR]
             await self._instance.set_color(color)
 
-        if ATTR_BRIGHTNESS in kwargs:
-            await self._instance.set_color_brightness(kwargs[ATTR_BRIGHTNESS])
-
-        if ATTR_EFFECT in kwargs:
+        if ATTR_EFFECT in kwargs and kwargs[ATTR_EFFECT]:
             await self._instance.set_effect(kwargs[ATTR_EFFECT])
 
 


### PR DESCRIPTION
After PR https://github.com/home-assistant/core/pull/101946 in home-assistant/core we need to check attrs for `NoneType` before continuing. And ATTR_WHITE was dropped.