### PR TITLE
Check discovered device has name attribute to prevent failure

### DIFF
--- a/beurer.py
+++ b/beurer.py
@@ -14,7 +14,7 @@ async def discover():
     """Discover Bluetooth LE devices."""
     devices = await BleakScanner.discover()
     LOGGER.debug("Discovered devices: %s", [{"address": device.address, "name": device.name} for device in devices])
-    return [device for device in devices if device.name.lower().startswith("tl100")]
+    return [device for device in devices if device.name and device.name.lower().startswith("tl100")]
 
 def create_status_callback(future: asyncio.Future):
     def callback(sender: int, data: bytearray):


### PR DESCRIPTION
If discovered devices do not have a name attribute .lower will fail with:

`AttributeError: 'NoneType' object has no attribute 'lower'`

Fixes #8